### PR TITLE
Unbundle Polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.0.4] - [Unreleased]
+
+### Changed
+
+- Removed bundled polyfill
+
+## [0.0.1] - 2017-07-09
+
+### Released

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # \<watsonlogic-parallax\>
 
-Parallax scrolling effect web component for Polymer 2.0.
+Parallax scrolling effect web component made with Polymer 2.0. Import [Web Component polyfills](https://github.com/webcomponents/webcomponentsjs) if needed.
 
 <!--
 ```
@@ -48,4 +48,5 @@ Parallax scrolling effect web component for Polymer 2.0.
 ![Demo Preview](https://github.com/watsonlogic-software/watsonlogic-parallax/blob/master/preview.gif?raw=true)
 
 ## License
+
 Apache License 2.0

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
 
     <title>watsonlogic-parallax demo</title>
 
-    <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
 
     <title>watsonlogic-parallax demo</title>
 
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">

--- a/watsonlogic-parallax.html
+++ b/watsonlogic-parallax.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer-element.html">
-<script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 
 <dom-module id="watsonlogic-parallax">
   <template>


### PR DESCRIPTION
Most people using Web Components or Polymer will already have polyfills set up already so we shouldn't load it in automatically. However, because this element can be outside of a Polymer application we should still mention it in the docs.